### PR TITLE
Upgrade to ZNC 1.6.1 & ngrok 2

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -7,17 +7,17 @@ cd $DIR; cp -R ../files/run_znc.sh $1/run_znc.sh
 cd $DIR; cp -R ../files/ngrok $1/ngrok
 mkdir -p /app
 mkdir -p $2
-if [ -f $2/znc-1.4.tar.gz ]; then
+if [ -f $2/znc-1.6.1.tar.gz ]; then
   echo "-----> znc is already compiled"
-  cd $2/znc-1.4; make install
+  cd $2/znc-1.6.1; make install
   cp -R /app/znc/ $1/
 else
   echo "-----> downloading and compile znc"
-  cd $2; curl -O http://znc.in/releases/znc-1.4.tar.gz
-  cd $2; tar zxvf znc-1.4.tar.gz
-  cd $2/znc-1.4; ./configure --prefix="/app/znc"
-  cd $2/znc-1.4; make
-  cd $2/znc-1.4; make install
+  cd $2; curl -O http://znc.in/releases/znc-1.6.1.tar.gz
+  cd $2; tar zxvf znc-1.6.1.tar.gz
+  cd $2/znc-1.6.1; ./configure --prefix="/app/znc"
+  cd $2/znc-1.6.1; make
+  cd $2/znc-1.6.1; make install
   cp -R /app/znc/ $1/
 
 fi

--- a/files/run_znc.sh
+++ b/files/run_znc.sh
@@ -1,6 +1,7 @@
 ./znc/bin/znc -f &
 export ZNCPID=$!
-./ngrok -authtoken $NGROK_API_KEY -log=stdout --config ngrok.conf start znc &
+./ngrok authtoken $NGROK_API_KEY
+./ngrok start znc --log "stdout" --config /app/.ngrok2/ngrok.yml --config ngrok.conf
 export NGROKPID=$!
 echo "waiting for znc ($ZNCPID) to exit......."
 while [ -e /proc/$ZNCPID ]


### PR DESCRIPTION
This likely could use some README updates and updates to the example project, but I've got it working for my own use so far.

Fair warning: Having "flood" and "irc" mentioned in my `znc.conf` file set off an automated security scanner at Heroku and got my account suspended. I was able to get un-suspended, and their Security folks don't intend to block either ZNC or ngrok from being used on Heroku. (Full disclosure: I work for Heroku and was able to talk to the security folks myself and explain the situation. However, I don't want to get a bunch of people's accounts suspended. You've been warned.)
