### PR TITLE
-> znc 1.6.4

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -7,17 +7,17 @@ cd $DIR; cp -R ../files/run_znc.sh $1/run_znc.sh
 cd $DIR; cp -R ../files/ngrok $1/ngrok
 mkdir -p /app
 mkdir -p $2
-if [ -f $2/znc-1.6.1.tar.gz ]; then
+if [ -f $2/znc-1.6.4.tar.gz ]; then
   echo "-----> znc is already compiled"
-  cd $2/znc-1.6.1; make install
+  cd $2/znc-1.6.4; make install
   cp -R /app/znc/ $1/
 else
   echo "-----> downloading and compile znc"
-  cd $2; curl -O http://znc.in/releases/znc-1.6.1.tar.gz
-  cd $2; tar zxvf znc-1.6.1.tar.gz
-  cd $2/znc-1.6.1; ./configure --prefix="/app/znc"
-  cd $2/znc-1.6.1; make
-  cd $2/znc-1.6.1; make install
+  cd $2; curl -O http://znc.in/releases/znc-1.6.4.tar.gz
+  cd $2; tar zxvf znc-1.6.4.tar.gz
+  cd $2/znc-1.6.4; ./configure --prefix="/app/znc"
+  cd $2/znc-1.6.4; make
+  cd $2/znc-1.6.4; make install
   cp -R /app/znc/ $1/
 
 fi


### PR DESCRIPTION
1.6.1 is not downloadable. 

Not sure if this code is maintained, or if it works - after fixing the version number, everything seemed to download fine on Heroku but then my account was suspended. Looking into that right now. But using 1.6.1 is definitely wrong.